### PR TITLE
Add centralized Slack notifier via /api/notify-lead

### DIFF
--- a/frontend/src/utils/notifyLead.ts
+++ b/frontend/src/utils/notifyLead.ts
@@ -1,0 +1,48 @@
+export type LeadPayload = Record<string, any>;
+
+function utmFromLocation() {
+  if (typeof window === 'undefined') return {} as Record<string, string>;
+  const q = new URLSearchParams(window.location.search);
+  return {
+    utm_source: q.get('utm_source') || '',
+    utm_medium: q.get('utm_medium') || '',
+    utm_campaign: q.get('utm_campaign') || '',
+    utm_term: q.get('utm_term') || '',
+    utm_content: q.get('utm_content') || '',
+  } as Record<string, string>;
+}
+
+export async function notifyLead(context: string, payload: LeadPayload) {
+  try {
+    await fetch('https://utlyzecom.vercel.app/api/notify-lead', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context, payload }),
+      // No-cors not needed; endpoint sends appropriate CORS headers
+    });
+  } catch (e) {
+    // best-effort only; do not block UX
+    console.warn('notifyLead failed', e);
+  }
+}
+
+export function buildBookingPayload(data: {
+  name: string; email: string; company: string;
+  challenge?: string; challengeDetails?: string;
+  preferredDate?: string; preferredTime?: string; timezone?: string;
+}) {
+  const page_url = typeof window !== 'undefined' ? window.location.href : '';
+  return {
+    name: data.name,
+    email: data.email,
+    company: data.company,
+    challenge: data.challenge,
+    challenge_details: data.challengeDetails,
+    preferred_date: data.preferredDate,
+    preferred_time: data.preferredTime,
+    timezone: data.timezone,
+    page_url,
+    ...utmFromLocation(),
+  };
+}
+


### PR DESCRIPTION
This PR adds a fire-and-forget Slack notifier that posts to our centralized endpoint (utlyzecom.vercel.app/api/notify-lead). It sends relevant form payload + page_url + UTM, without blocking UX. After utlyze.com is reattached, we can switch endpoint to utlyze.com/api/notify-lead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sends a background notification after a successful booking to ensure timely follow-up.
  - Captures UTM parameters and the page URL with each booking to improve context and personalization.
  - Runs asynchronously without affecting the booking experience or slowing submission.

- Chores
  - Added utilities to support lead notifications and payload construction for bookings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->